### PR TITLE
remove timestep from Q

### DIFF
--- a/kernels-v1/attention-int8/attention_int8_cuda/attention_int8.cu
+++ b/kernels-v1/attention-int8/attention_int8_cuda/attention_int8.cu
@@ -174,7 +174,7 @@ int8_attention_kernel(
     for (int i = tid; i < q_size * HEAD_DIM; i += THREADS)
         lqmax = fmaxf(lqmax, fabsf(__half2float(Q_head[q_start * HEAD_DIM + i])));
     float abs_max_Q   = block_reduce_max(lqmax, warp_scr);
-    const float inv_Q = 127.f / fmaxf(abs_max_Q * ts, 1e-6f);
+    const float inv_Q = 127.f / fmaxf(abs_max_Q, 1e-6f);
     const float scl_Q = 1.f / inv_Q;
 
     // Quantize Q tile


### PR DESCRIPTION
Applied the fix removing ts from the Q scale computation. Here are the results:

| Fix | Mean diff | Max diff |
|---|---|---|
| Baseline | 0.168081 | 1.693359 |
| Symmetric range | 0.168939 | 1.614502 |
| Remove ts from Q scale | 0.166455 | 1.372681 |

The mean difference barely moved, but the max dropped from 1.69 to 1.37. It seems ts was causing spikes on specific values rather than a uniform error across the board. That makes sense since ts only distorts the scale factor, and the impact depends on how far each value is from the tile's max.

Let me know if we merge this first or should instead work on the data itslef